### PR TITLE
Enable python server

### DIFF
--- a/lungair/README.md
+++ b/lungair/README.md
@@ -64,10 +64,20 @@ Once you have the pre-requisites, follow the steps listed below:
    pop-up window. See this [test data document](https://docs.google.com/document/d/10RnVyF1etl_17pyCyK96tyhUWRbrTyEcqpwzW-Z-Ybs/edit)
    for credentials to use on Oracle's public test server.
 
-6. VolView Python backend server.
+6. Python backend server.
 
    VolView's python server can be used to run backend jobs such as deep learning inference pipelines.
-   Start an instance of the python server by following the [quick-start guide](../documentation/content/doc/server-dev.md#starting-the-server).
+   Following the [quick-start guide](../documentation/content/doc/server-dev.md#starting-the-server),
+   install [Poetry](https://python-poetry.org/), create a new Python environment for
+   running the VolView server, and install the server dependencies:
+   ```bash
+   cd lungair-web-application/server/
+   poetry install
+   ```
+   Then, from the same directory, run the server as follows:
+   ```bash
+   poetry run python -m volview_server -P 4014 ../lungair/python/lungair_methods.py
+   ```
 
 ## Acknowledgments
 

--- a/lungair/README.md
+++ b/lungair/README.md
@@ -67,10 +67,7 @@ Once you have the pre-requisites, follow the steps listed below:
 6. VolView Python backend server.
 
    VolView's python server can be used to run backend jobs such as deep learning inference pipelines.
-   Start an instance of the python server by following the [quick-start guide](../documentation/content/doc/server-dev.md#starting-the-server).\
-   _NOTE: "Remote Functions" tab from VolView is currently disabled in LungAir customization.
-    We will soon add some functions to talk to the python server in our own custom "LUNGAIR EHR" tab.
-    Meanwhile, you can re-enable it locally for testing purposes. Go to `ModulePanel.vue` and uncomment the lines that declare the `ServerModule`._
+   Start an instance of the python server by following the [quick-start guide](../documentation/content/doc/server-dev.md#starting-the-server).
 
 ## Acknowledgments
 

--- a/lungair/python/lungair_methods.py
+++ b/lungair/python/lungair_methods.py
@@ -1,0 +1,85 @@
+import asyncio
+from concurrent.futures import ProcessPoolExecutor
+
+import itk
+
+itk.force_load()
+
+from volview_server import (
+    VolViewApi,
+    get_current_client_store,
+    get_current_session,
+)
+
+from volview_server.transformers import (
+    convert_itk_to_vtkjs_image,
+    convert_vtkjs_to_itk_image,
+)
+
+from methods.methods_utils import (
+    show_image,
+    CommonClientState,
+)
+
+from methods.median_filter_method import (
+    MedianFilterClientState,
+    median_filter_method,
+)
+
+
+## Link to app ##
+
+
+volview = VolViewApi()
+
+
+## Allocate process pool ##
+
+
+process_pool = ProcessPoolExecutor(4)
+
+
+## Compose the Client State ##
+
+
+class CurrentClientState:
+    def __init__(self):
+        self.common = CommonClientState()
+        self.median_filter = MedianFilterClientState()
+
+
+## Median filter ##
+
+
+@volview.expose("medianFilter")
+async def median_filter_api(input_image_id, radius):
+    print(f"Started median filter on {input_image_id}.")
+    store = get_current_client_store("images")
+    state = get_current_session(default_factory=CurrentClientState)
+
+    # Set state variables used by median filter - current_image
+    image = await store.dataIndex[input_image_id]
+    serialized_image = convert_itk_to_vtkjs_image(image)
+    state.common.set_current_image(input_image_id, serialized_image)
+
+    # Set state variables used by median filter - radius
+    state.median_filter.set_radius(radius)
+
+    # we need to run the median filter in a subprocess,
+    # since itk blocks the GIL.
+    loop = asyncio.get_event_loop()
+    serialized_output = await loop.run_in_executor(
+        process_pool,
+        median_filter_method,
+        state,
+    )
+
+    # convert image to back to itkImage
+    output_image = convert_vtkjs_to_itk_image(serialized_output)
+    output_image_id = await store.addVTKImageData(
+        "Median filtered image",
+        output_image,
+    )
+    state.common.associate_derived_image(input_image_id, output_image_id)
+
+    await show_image(output_image_id)

--- a/lungair/src/components/LungairServerModule.vue
+++ b/lungair/src/components/LungairServerModule.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useCurrentImage } from '../../../src/composables/useCurrentImage';
+import { useServerStore, ConnectionState } from '../../../src/store/server';
+
+const serverStore = useServerStore();
+const { client } = serverStore;
+const ready = computed(
+  () => serverStore.connState === ConnectionState.Connected
+);
+
+// --- median filter --- //
+
+const medianFilterLoading = ref(false);
+const { currentImageID } = useCurrentImage();
+const medianFilterRadius = ref(2);
+
+const doMedianFilter = async () => {
+  const id = currentImageID.value;
+  if (!id) return;
+
+  medianFilterLoading.value = true;
+  try {
+    await client.call('medianFilter', [id, medianFilterRadius.value]);
+  } finally {
+    medianFilterLoading.value = false;
+  }
+};
+
+const hasCurrentImage = computed(() => !!currentImageID.value);
+</script>
+
+
+<template>
+  <div class="overflow-y-auto overflow-x-hidden ma-2 fill-height">
+    <v-alert v-if="!ready" color="info">Not connected to the server.</v-alert>
+    <v-divider />
+    <v-list-subheader>Median Filter</v-list-subheader>
+    <div>
+      <v-row>
+        <v-col cols="3">
+          <v-text-field
+            :model-value="medianFilterRadius"
+            @update:model-value="medianFilterRadius = Number($event || 0)"
+            type="number"
+            variant="outlined"
+            density="compact"
+            hide-details
+            placeholder="1"
+          />
+        </v-col>
+        <v-col>
+          <v-btn
+            @click="doMedianFilter"
+            :loading="medianFilterLoading"
+            :disabled="!ready || !hasCurrentImage"
+          >
+            Run Median Filter
+          </v-btn>
+          <span v-if="!hasCurrentImage" class="ml-4 body-2">
+            No image loaded
+          </span>
+        </v-col>
+      </v-row>
+    </div>
+  </div>
+</template>

--- a/src/components/ModulePanel.vue
+++ b/src/components/ModulePanel.vue
@@ -39,7 +39,7 @@ import { Component, defineComponent, ref, watch } from 'vue';
 import DataBrowser from './DataBrowser.vue';
 import RenderingModule from './RenderingModule.vue';
 import AnnotationsModule from './AnnotationsModule.vue';
-import ServerModule from './ServerModule.vue';
+import ServerModule from '../../lungair/src/components/LungairServerModule.vue';
 import { useToolStore } from '../store/tools';
 import { Tools } from '../store/tools/types';
 import EHRDataBrowser from '../../lungair/src/components/EHRDataBrowser.vue';

--- a/src/components/ModulePanel.vue
+++ b/src/components/ModulePanel.vue
@@ -39,7 +39,7 @@ import { Component, defineComponent, ref, watch } from 'vue';
 import DataBrowser from './DataBrowser.vue';
 import RenderingModule from './RenderingModule.vue';
 import AnnotationsModule from './AnnotationsModule.vue';
-// import ServerModule from './ServerModule.vue';
+import ServerModule from './ServerModule.vue';
 import { useToolStore } from '../store/tools';
 import { Tools } from '../store/tools/types';
 import EHRDataBrowser from '../../lungair/src/components/EHRDataBrowser.vue';
@@ -66,13 +66,11 @@ const Modules: Module[] = [
     icon: 'cube',
     component: RenderingModule,
   },
-  /*
   {
     name: 'Remote',
     icon: 'server-network',
     component: ServerModule,
   },
-  */
   {
     name: 'LungAir EHR',
     icon: 'database',


### PR DESCRIPTION
closes #5 

- adds a server vue component by copying the `ServerModule.vue` into `lungair/LungairServerModule.vue`. only controls for the median filter are kept.
- enables that component in volview `ModulePanel.vue`
- adds a python module that contains only a median filter and that is isolated in a new directory `lungair/python/`
- updates readme instructions for python server setup