### PR TITLE
Updated layout for LungAir

### DIFF
--- a/lungair/src/components/AnalyticsView.vue
+++ b/lungair/src/components/AnalyticsView.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="overflow-y-auto mx-2 fill-height">
+    <h3 class="mt-2">Analytics View</h3>
+    <v-divider class="mb-2" />
+  </div>
+</template>
+
+<style scoped>
+</style>
+
+<script lang="ts">
+
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'AnalyticsView',
+  components: {
+  },
+  setup() {
+
+    return {
+    };
+  },
+});
+</script>

--- a/lungair/src/components/ChartView.vue
+++ b/lungair/src/components/ChartView.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="overflow-y-auto mx-2 fill-height">
+    <h3 class="mt-2">Chart View</h3>
+    <v-divider class="mb-2" />
+  </div>
+</template>
+
+<style scoped>
+</style>
+
+<script lang="ts">
+
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'ChartView',
+  components: {
+  },
+  setup() {
+
+    return {
+    };
+  },
+});
+</script>

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -348,7 +348,7 @@ export default defineComponent({
 
     // --- layout --- //
 
-    const layoutName: Ref<string> = ref('Quad View');
+    const layoutName: Ref<string> = ref('LungAir Primary');
     const { layout: currentLayout } = storeToRefs(viewStore);
 
     watch(

--- a/src/components/LayoutGrid.vue
+++ b/src/components/LayoutGrid.vue
@@ -19,6 +19,8 @@ import { Component, computed, defineComponent, PropType, toRefs } from 'vue';
 import { storeToRefs } from 'pinia';
 import VtkTwoView from './VtkTwoView.vue';
 import VtkThreeView from './VtkThreeView.vue';
+import AnalyticsView from '../../lungair/src/components/AnalyticsView.vue';
+import ChartView from '../../lungair/src/components/ChartView.vue';
 import { Layout, LayoutDirection } from '../types/layout';
 import { useViewStore } from '../store/views';
 import { ViewType } from '../types/views';
@@ -26,6 +28,8 @@ import { ViewType } from '../types/views';
 const TYPE_TO_COMPONENT: Record<ViewType, Component> = {
   '2D': VtkTwoView,
   '3D': VtkThreeView,
+  Analytics: AnalyticsView,
+  Chart: ChartView,
 };
 
 export default defineComponent({

--- a/src/components/ModulePanel.vue
+++ b/src/components/ModulePanel.vue
@@ -37,7 +37,6 @@
 import { Component, defineComponent, ref, watch } from 'vue';
 
 import DataBrowser from './DataBrowser.vue';
-import RenderingModule from './RenderingModule.vue';
 import AnnotationsModule from './AnnotationsModule.vue';
 import ServerModule from '../../lungair/src/components/LungairServerModule.vue';
 import { useToolStore } from '../store/tools';
@@ -60,11 +59,6 @@ const Modules: Module[] = [
     name: 'Annotations',
     icon: 'pencil',
     component: AnnotationsModule,
-  },
-  {
-    name: 'Rendering',
-    icon: 'cube',
-    component: RenderingModule,
   },
   {
     name: 'Remote',

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,8 @@ export const InitViewIDs: Record<string, string> = {
   Sagittal: 'Sagittal',
   Axial: 'Axial',
   Three: '3D',
+  Chart: 'Chart',
+  Analytics: 'Analytics',
 };
 
 /**
@@ -49,6 +51,14 @@ export const InitViewSpecs: Record<string, ViewSpec> = {
       viewUp: 'Superior',
     },
   },
+  [InitViewIDs.Chart]: {
+    viewType: 'Chart',
+    props: {},
+  },
+  [InitViewIDs.Analytics]: {
+    viewType: 'Analytics',
+    props: {},
+  },
 };
 
 /**
@@ -60,6 +70,18 @@ export const DefaultViewSpec = InitViewSpecs[InitViewIDs.Axial];
  * Defines the default layouts.
  */
 export const Layouts: Record<string, Layout> = [
+  {
+    name: 'LungAir Primary',
+    direction: LayoutDirection.H,
+    items: [
+      InitViewIDs.Axial,
+      {
+        direction: LayoutDirection.V,
+        items: [InitViewIDs.Chart, InitViewIDs.Analytics],
+      },
+    ],
+  },
+  /*
   {
     name: 'Axial Only',
     direction: LayoutDirection.H,
@@ -106,6 +128,7 @@ export const Layouts: Record<string, Layout> = [
     direction: LayoutDirection.H,
     items: [InitViewIDs.Three],
   },
+  */
 ].reduce((layouts, layout) => {
   return { ...layouts, [layout.name]: layout };
 }, {});

--- a/src/io/state-file/schema.ts
+++ b/src/io/state-file/schema.ts
@@ -218,6 +218,8 @@ const ViewConfig = z.object({
 const ViewType = z.union([
   z.literal('2D'),
   z.literal('3D'),
+  z.literal('Chart'),
+  z.literal('Analytics'),
 ]) satisfies z.ZodType<ViewType>;
 
 export type ViewConfig = z.infer<typeof ViewConfig>;

--- a/src/store/data-browser.ts
+++ b/src/store/data-browser.ts
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia';
 import { ref } from 'vue';
 
 export const useDataBrowserStore = defineStore('data-browser', () => {
-  const hideSampleData = ref(false);
+  const hideSampleData = ref(true);
   return {
     hideSampleData,
   };

--- a/src/types/views.ts
+++ b/src/types/views.ts
@@ -4,7 +4,7 @@ import {
   PiecewiseNode,
 } from '@kitware/vtk.js/Proxy/Core/PiecewiseFunctionProxy';
 
-export type ViewType = '2D' | '3D';
+export type ViewType = '2D' | '3D' | 'Chart' | 'Analytics';
 
 export interface ViewSpec {
   viewType: ViewType;


### PR DESCRIPTION
Closes #14 
## Brief Description
Update the layout to only show three viewports:
- 2D view (currently axial)
- Chart view (to show patient data over timeline).
- Analytics view (to show risk assessments / prediction output from backend & deep learning pipelines).

Additionally, simplify the user-interface through:
- disable all other layouts
- remove Rendering module (3D rendering properties)
- disable Sample data card

## Results / Output:
<img width="1220" alt="image" src="https://github.com/KitwareMedical/lungair-web-application/assets/22624785/f353a77c-d7af-48f1-9700-ede8baf7b4b6">

